### PR TITLE
Touch Framework Shell Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 out
 
 .idea
+
+local.properties

--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/tasks/CocoapodsTasks.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/tasks/CocoapodsTasks.kt
@@ -103,7 +103,13 @@ open class PodspecTask : DefaultTask() {
             |                    -P${KotlinCocoapodsPlugin.HEADER_PATHS_PROPERTY}="${'$'}HEADER_SEARCH_PATHS" \
             |                    -P${KotlinCocoapodsPlugin.FRAMEWORK_PATHS_PROPERTY}="${'$'}FRAMEWORK_SEARCH_PATHS"
             |            SCRIPT
-            |        }
+            |        },
+			|        {
+			|        	:name => 'Touch $specName.framework',
+			|        	:execution_position => :after_compile,
+			|        	:shell_path =>  '/bin/sh',
+			|        	:script => 'find "${'$'}{SRCROOT}" -type f -name *frameworks.sh -exec bash -c "touch \"{}\"" \;'
+			|        }
             |    ]
             |end
         """.trimMargin()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=co.touchlab
-VERSION_NAME=0.7
+VERSION_NAME=0.8
 
 POM_URL=https://github.com/touchlab/KotlinCocoapods/
 POM_SCM_URL=https://github.com/touchlab/KotlinCocoapods/

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Apr 27 15:26:16 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip

--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Mon Apr 27 15:21:00 EDT 2020
-sdk.dir=/Users/benwhitley/Library/Android/sdk

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,8 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#Mon Apr 27 15:21:00 EDT 2020
+sdk.dir=/Users/benwhitley/Library/Android/sdk


### PR DESCRIPTION
Now generates a podspec with an additional script phase that will reload the framework to check for and pull in new Kotlin code.

I think there's room for improvement on the script. Ideally it would only touch the shared Kotlin library. Currently it touches all frameworks.