### PR TITLE
Allow Framework Configuration

### DIFF
--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt
@@ -48,11 +48,6 @@ open class CocoapodsExtension(private val project: Project) {
     @Input
     var homepage: String? = null
 
-    @Internal
-    internal var frameworkName: String = project.name.asValidFrameworkName()
-    @Internal
-    internal var isStatic: Boolean = true
-    @Internal
     internal var frameworkConfiguration: Framework.() -> Unit = {
         baseName = project.name.asValidFrameworkName()
         isStatic = true
@@ -60,8 +55,6 @@ open class CocoapodsExtension(private val project: Project) {
 
     internal fun configureFramework(framework: Framework){
         frameworkConfiguration(framework)
-        frameworkName = framework.baseName
-        isStatic = framework.isStatic
     }
 
     @Optional

--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt
@@ -48,13 +48,16 @@ open class CocoapodsExtension(private val project: Project) {
     @Input
     var homepage: String? = null
 
-    internal var frameworkConfiguration: Framework.() -> Unit = {
+    private fun Framework.setDefaults(){
         baseName = project.name.asValidFrameworkName()
         isStatic = true
     }
 
+    internal var frameworkConfiguration: Framework.() -> Unit = {}
+
     internal fun configureFramework(framework: Framework){
-        frameworkConfiguration(framework)
+        framework.setDefaults()
+        framework.frameworkConfiguration()
     }
 
     @Optional

--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
@@ -166,21 +166,23 @@ open class KotlinCocoapodsPlugin : Plugin<Project> {
             kotlinExtension: KotlinMultiplatformExtension,
             cocoapodsExtension: CocoapodsExtension
     ) {
-        val firstReleaseFramework = kotlinExtension.supportedTargets()
+        val firstFramework = kotlinExtension.supportedTargets()
                 .single()
                 .binaries
-                .getFramework(NativeBuildType.RELEASE)
+                .run {
+                    findFramework(NativeBuildType.RELEASE) ?: getFramework(NativeBuildType.DEBUG)
+                }
 
         val dummyFrameworkTask = project.tasks.create("generateDummyFramework", DummyFrameworkTask::class.java) {
             it.settings = cocoapodsExtension
-            it.framework = firstReleaseFramework
+            it.framework = firstFramework
         }
 
         project.tasks.create("podspec", PodspecTask::class.java) {
             it.group = TASK_GROUP
             it.description = "Generates a podspec file for CocoaPods import"
             it.settings = cocoapodsExtension
-            it.framework = firstReleaseFramework
+            it.framework = firstFramework
             it.dependsOn(dummyFrameworkTask)
             val generateWrapper = project.findProperty(GENERATE_WRAPPER_PROPERTY)?.toString()?.toBoolean() ?: false
             if (generateWrapper) {

--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
@@ -18,6 +18,8 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import co.touchlab.kotlin.gradle.tasks.*
 import co.touchlab.kotlin.gradle.utils.asValidTaskName
 import co.touchlab.kotlin.gradle.utils.lowerCamelCaseName
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.tasks.FatFrameworkTask
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
@@ -63,11 +65,8 @@ open class KotlinCocoapodsPlugin : Plugin<Project> {
 
     private fun createDefaultFrameworks(kotlinExtension: KotlinMultiplatformExtension, cocoapodsExtension: CocoapodsExtension) {
         kotlinExtension.supportedTargets().all { target ->
-            target.binaries.framework {
-                baseName = cocoapodsExtension.frameworkName
-//                baseNameProvider = project.provider { cocoapodsExtension.frameworkName }
-                println("cocoapodsExtension.isStatic ${cocoapodsExtension.isStatic}")
-                isStatic = cocoapodsExtension.isStatic
+            target.binaries.framework{
+                cocoapodsExtension.configureFramework(this)
             }
         }
     }

--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/tasks/CocoapodsTasks.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/tasks/CocoapodsTasks.kt
@@ -18,6 +18,7 @@ import co.touchlab.kotlin.gradle.plugin.cocoapods.KotlinCocoapodsPlugin.Companio
 import co.touchlab.kotlin.gradle.plugin.cocoapods.KotlinCocoapodsPlugin.Companion.SYNC_TASK_NAME
 import co.touchlab.kotlin.gradle.plugin.cocoapods.asValidFrameworkName
 import co.touchlab.kotlin.gradle.plugin.cocoapods.cocoapodsBuildDirs
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import java.io.File
 
 /**
@@ -32,10 +33,13 @@ open class PodspecTask : DefaultTask() {
     val outputFile: File = project.projectDir.resolve("$specName.podspec")
 
     @Input
-    val frameworkNameProvider: Provider<String> = project.provider { settings.frameworkName }
+    val frameworkNameProvider: Provider<String> = project.provider { framework.baseName}
 
     @get:Nested
     internal lateinit var settings: CocoapodsExtension
+
+    @get:Nested
+    internal lateinit var framework: Framework
 
     // TODO: Handle Framework name customization - rename the framework during sync process.
     @TaskAction
@@ -71,7 +75,7 @@ open class PodspecTask : DefaultTask() {
             |    spec.license                  = '${settings.license.orEmpty()}'
             |    spec.summary                  = '${settings.summary.orEmpty()}'
             |
-            |${if(settings.isStatic){"    spec.static_framework         = true"}else{""}}
+            |${if(framework.isStatic){"    spec.static_framework         = true"}else{""}}
             |    spec.vendored_frameworks      = "$frameworkDir/${frameworkNameProvider.get()}.framework"
             |    spec.libraries                = "c++"
             |    spec.module_name              = "#{spec.name}_umbrella"
@@ -137,10 +141,13 @@ open class DummyFrameworkTask : DefaultTask() {
     val destinationDir = project.cocoapodsBuildDirs.framework
 
     @Input
-    val frameworkNameProvider: Provider<String> = project.provider { settings.frameworkName }
+    val frameworkNameProvider: Provider<String> = project.provider { framework.baseName }
 
     @get:Nested
     internal lateinit var settings: CocoapodsExtension
+
+    @get:Nested
+    internal lateinit var framework: Framework
 
     private val frameworkDir: File
         get() = destinationDir.resolve("${frameworkNameProvider.get()}.framework")


### PR DESCRIPTION
Lets you include a framework block in the cocoapods extension which matches the one used when creating a framework binary. Letting you configure whatever you might want eg. isStatic, exports, baseName

Note this is a breaking change as is because I remove the properties that were previously being passed through