### PR TITLE
Use first framework

### DIFF
--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt
@@ -6,6 +6,7 @@
 @file:Suppress("PackageDirectoryMismatch") // Old package for compatibility
 package co.touchlab.kotlin.gradle.plugin.cocoapods
 
+import org.gradle.api.Action
 import org.gradle.api.Named
 import org.gradle.api.NamedDomainObjectSet
 import org.gradle.api.Project
@@ -48,22 +49,22 @@ open class CocoapodsExtension(private val project: Project) {
     @Input
     var homepage: String? = null
 
-    private fun Framework.setDefaults(){
+    private fun Framework.setDefaults() {
         baseName = project.name.asValidFrameworkName()
         isStatic = true
     }
 
-    internal var frameworkConfiguration: Framework.() -> Unit = {}
-
-    internal fun configureFramework(framework: Framework){
-        framework.setDefaults()
-        framework.frameworkConfiguration()
+    internal fun configureFramework(frameworkToConfigure: Framework) {
+        frameworkToConfigure.setDefaults()
+        frameworkAction?.execute(frameworkToConfigure)
     }
 
-    @Optional
-    @Input
-    fun framework(configure: Framework.() -> Unit) {
-        frameworkConfiguration = configure
+    //Not an input because we pull relevant values from the configured frameworks instead of here
+    @Internal
+    var frameworkAction: Action<Framework>? = null
+
+    fun framework(action: Action<Framework>) {
+        frameworkAction = action
     }
 
     private val _pods = project.container(CocoapodsDependency::class.java)

--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
@@ -174,15 +174,15 @@ open class KotlinCocoapodsPlugin : Plugin<Project> {
                 }
 
         val dummyFrameworkTask = project.tasks.create("generateDummyFramework", DummyFrameworkTask::class.java) {
-            it.settings = cocoapodsExtension
-            it.framework = firstFramework
+            it.frameworkName = firstFramework.baseName
         }
 
         project.tasks.create("podspec", PodspecTask::class.java) {
             it.group = TASK_GROUP
             it.description = "Generates a podspec file for CocoaPods import"
             it.settings = cocoapodsExtension
-            it.framework = firstFramework
+            it.frameworkName = firstFramework.baseName
+            it.isStatic = firstFramework.isStatic
             it.dependsOn(dummyFrameworkTask)
             val generateWrapper = project.findProperty(GENERATE_WRAPPER_PROPERTY)?.toString()?.toBoolean() ?: false
             if (generateWrapper) {

--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
@@ -167,7 +167,7 @@ open class KotlinCocoapodsPlugin : Plugin<Project> {
             cocoapodsExtension: CocoapodsExtension
     ) {
         val firstFramework = kotlinExtension.supportedTargets()
-                .single()
+                .first()
                 .binaries
                 .run {
                     findFramework(NativeBuildType.RELEASE) ?: getFramework(NativeBuildType.DEBUG)

--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/tasks/CocoapodsTasks.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/tasks/CocoapodsTasks.kt
@@ -33,10 +33,10 @@ open class PodspecTask : DefaultTask() {
     val outputFile: File = project.projectDir.resolve("$specName.podspec")
 
     @get:Input
-    lateinit var frameworkName:String
+    internal lateinit var frameworkName:String
 
     @get:Input
-    var isStatic:Boolean = true
+    internal var isStatic:Boolean = true
 
     @get:Nested
     internal lateinit var settings: CocoapodsExtension


### PR DESCRIPTION
Get the framework from the first target rather than using single(). There may be multiple supported targets. We can grab just the first because we configure the framework the same for every supported target