### PR TITLE
Support the ability for pods to be declared “link only”

### DIFF
--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt
@@ -86,15 +86,16 @@ open class CocoapodsExtension(private val project: Project) {
      * Add a CocoaPods dependency to the pod built from this project.
      */
     @JvmOverloads
-    fun pod(name: String, version: String? = null, moduleName: String = name.split("/")[0]) {
+    fun pod(name: String, version: String? = null, moduleName: String = name.split("/")[0], linkOnly: Boolean = false) {
         check(_pods.findByName(name) == null) { "Project already has a CocoaPods dependency with name $name" }
-        _pods.add(CocoapodsDependency(name, version, moduleName))
+        _pods.add(CocoapodsDependency(name, version, moduleName, linkOnly))
     }
 
     data class CocoapodsDependency(
             private val name: String,
             @get:Optional @get:Input val version: String?,
-            @get:Input val moduleName: String
+            @get:Input val moduleName: String,
+            @get:Input val linkOnly: Boolean
     ) : Named {
         @Input
         override fun getName(): String = name

--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/cocoapods/KotlinCocoapodsPlugin.kt
@@ -198,7 +198,7 @@ open class KotlinCocoapodsPlugin : Plugin<Project> {
     ) {
         val moduleNames = mutableSetOf<String>()
         cocoapodsExtension.pods.all { pod ->
-            if (moduleNames.contains(pod.moduleName)) {
+            if (moduleNames.contains(pod.moduleName) || pod.linkOnly) {
                 return@all
             }
             moduleNames.add(pod.moduleName)


### PR DESCRIPTION
There's some libraries out there like: https://github.com/icerockdev/moko-socket-io

That ask you to add it as a dependency in cocoa pods, but only link and not run the cinterop.
This PR adds a flag that allows you to mark a dependency as link only.