### PR TITLE
Update header file name for Kotlin 1.4.20

### DIFF
--- a/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/tasks/CocoapodsTasks.kt
+++ b/gradle-plugin/src/main/kotlin/co/touchlab/kotlin/gradle/targets/native/tasks/CocoapodsTasks.kt
@@ -197,7 +197,7 @@ open class DummyFrameworkTask : DefaultTask() {
         // Copy files for the dummy framework.
         copyFrameworkFile("Info.plist")
         copyFrameworkFile("dummy", frameworkName)
-        copyFrameworkFile("Headers/dummy.h")
+        copyFrameworkFile("Headers/placeholder.h")
         copyFrameworkTextFile("Modules/module.modulemap") {
             if (it == "framework module dummy {") {
                 it.replace("dummy", frameworkName)


### PR DESCRIPTION
Tracking https://github.com/JetBrains/kotlin/commit/7c3eda31fa176dcfa7a81b82496806bde65b2892 to start support for Kotlin 1.4.20 and newer.

Refs #21