### PR TITLE
Do not depend on kotlin-native-utils jar

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -26,7 +26,8 @@ tasks.getByName('pluginUnderTestMetadata').
 
 dependencies {
   implementation deps.kotlin.stdlib.jdk
-  implementation deps.kotlin.native_utils
+  // Required for utility classes related to native platforms (e.g. KonanTarget).
+  implementation deps.kotlin.compiler
 
   compileOnly gradleApi()
   compileOnly deps.plugins.kotlinDependency

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ ext.deps = [
         stdlib: [
             jdk: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlinDependency}",
         ],
-        native_utils: "org.jetbrains.kotlin:kotlin-native-utils:${versions.kotlinDependency}",
+        compiler: "org.jetbrains.kotlin:kotlin-compiler-embeddable:${versions.kotlinDependency}",
         test: [
             common: "org.jetbrains.kotlin:kotlin-test-common:${versions.kotlinDependency}",
             commonAnnotations: "org.jetbrains.kotlin:kotlin-test-annotations-common:${versions.kotlinDependency}",


### PR DESCRIPTION
Hi!

We are going to stop publishing `kotlin-native-utils.jar` as a separate artifact. The content of this jar is already included into the `kotlin-compiler-embeddable` fat jar, so I've replaced the utils dependency with it.

See also: https://github.com/cashapp/sqldelight/pull/2236.